### PR TITLE
fix: function parse_page_fp_filename failing

### DIFF
--- a/dl.py
+++ b/dl.py
@@ -275,7 +275,7 @@ class MoodleDL:
         for a in content.find('a'):
             href = a.attrs.get('href')
 
-            if "mod_folder" not in href:
+            if href is None or "mod_folder" not in href:
                 continue
 
             dl_url = href


### PR DESCRIPTION
was failing if content had an anchor tag without href defined